### PR TITLE
object parsing for graph response

### DIFF
--- a/graphspace_python/api/obj/graph.py
+++ b/graphspace_python/api/obj/graph.py
@@ -1,0 +1,19 @@
+from graphspace_python.api.obj.response_object import ResponseObject
+
+class Graph(ResponseObject):
+
+    _fields = [
+        'id',
+        'name',
+        'owner_email',
+        'is_public',
+        'created_at',
+        'updated_at',
+        'tags',
+        'style_json',
+        'graph_json',
+        'default_layout_id'
+    ]
+
+    def __init__(self, response):
+        super(Graph, self).__init__(response)

--- a/graphspace_python/api/obj/multiple_graph_response.py
+++ b/graphspace_python/api/obj/multiple_graph_response.py
@@ -1,0 +1,12 @@
+from graphspace_python.api.obj.graph import Graph
+from graphspace_python.api.obj.response_object import ResponseObject
+
+class MultipleGraphResponse(ResponseObject):
+
+    _fields = [
+        'total'
+    ]
+
+    def __init__(self, response):
+        super(MultipleGraphResponse, self).__init__(response)
+        self._parse('graphs', Graph, response)

--- a/graphspace_python/api/obj/response_object.py
+++ b/graphspace_python/api/obj/response_object.py
@@ -1,0 +1,17 @@
+class ResponseObject(object):
+    _fields = []
+
+    def __init__(self, response):
+        for field in self._fields:
+            value = response[field] if field in response else None
+            self.__setattr__(field, value)
+
+    def _parse(self, field_name, cls_name, response):
+        if response and field_name in response:
+            self.__setattr__(
+                field_name,
+                [cls_name(field) for field in response[field_name]]
+            )
+
+    def _parse_response_body(self, field_name, cls_name, response):
+        self.__setattr__(field_name, cls_name(response))

--- a/graphspace_python/api/obj/single_graph_response.py
+++ b/graphspace_python/api/obj/single_graph_response.py
@@ -1,0 +1,8 @@
+from graphspace_python.api.obj.graph import Graph
+from graphspace_python.api.obj.response_object import ResponseObject
+
+class SingleGraphResponse(ResponseObject):
+
+    def __init__(self, response):
+        super(SingleGraphResponse, self).__init__(response)
+        self._parse_response_body('graph', Graph, response)


### PR DESCRIPTION
The response from the `/graphs` endpoint now can be mapped into two types of response objects:

1. `SingleGraphResponse`: The response received is an object which has a attribute `graph` which is of the class type `Graph` and contains the name,id,owner_email, etc field attributes.

2. `MultipleGraphResponse`: The response received is an object which has two attributes, `total` which is the total no. of results and `graphs` which is an array of objects of the class type `Graph`.

Should we be further creating more object types for the `graph_json` and `style_json` fields? Suggestions regarding changes are welcome. Will update the tests and docs after we are clear with our approach regarding this. 