### PR TITLE
Update request_path to HTTPS in client.py

### DIFF
--- a/graphspace_python/api/client.py
+++ b/graphspace_python/api/client.py
@@ -128,7 +128,7 @@ class GraphSpace(object):
 				'Content-Type': 'application/json'
 			}
 
-		request_path = 'http://{0}{1}?{2}'.format(
+		request_path = 'https://{0}{1}?{2}'.format(
 			self.api_host,
 			six.moves.urllib.parse.quote(path.encode('utf-8')),
 			six.moves.urllib.parse.urlencode(url_params, doseq=True)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 install_requires = [i.strip() for i in open("requirements.txt").readlines()]
 
 setup(name='graphspace_python',
-      version='0.9.1',
+      version='1.0.0',
       description='Python client for GraphSpace REST API',
       url='http://github.com/adbharadwaj/graphspace-python',
       author='Aditya Bharadwaj',


### PR DESCRIPTION
We have added HTTPS to [GraphSpace](https://www.graphspace.org). We tried to set up a Redirection rule on Apache which redirected from HTTP to HTTPS. The Redirection rule handled the GET requests without any problem. However, it is [tricky to redirect HTTP POST requests to HTTPS POST](https://softwareengineering.stackexchange.com/questions/99894/why-doesnt-http-have-post-redirect). The easier solution is changing request_path to HTTPS in client.py of graphspace-python. 