### PR TITLE
Extended the API interface for legend support

### DIFF
--- a/docs/_modules/graphspace_python.graphs.classes.rst
+++ b/docs/_modules/graphspace_python.graphs.classes.rst
@@ -28,6 +28,13 @@ graphspace\_python\.graphs\.classes\.gslayout module
     :undoc-members:
     :show-inheritance:
 
+graphspace\_python\.graphs\.classes\.gslegend module
+----------------------------------------------------
+
+.. automodule:: graphspace_python.graphs.classes.gslegend
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Module contents
 ---------------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -56,3 +56,11 @@ GSGroup Class
     :members:
     :undoc-members:
     :show-inheritance:
+
+GSLegend Class
+--------------
+
+.. automodule:: graphspace_python.graphs.classes.gslegend
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/tutorial/tutorial.rst
+++ b/docs/tutorial/tutorial.rst
@@ -851,6 +851,206 @@ You can also delete a group by passing the group object itself as param.
 u'Successfully deleted group with id=318'
 
 
+Creating a legend
+-----------------
+
+Create an empty legend.
+
+
+>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+>>> Ld = GSLegend()
+
+
+Adding legend key
+-----------------
+
+You can add an individual legend key at a time by using the 
+:meth:`~graphspace_python.graphs.classes.gsgraph.GSLegend.add_legend_entries` method.
+
+>>> # Adding a legend key with a given style and label
+>>> style = {'background-color': 'black', 'shape':'star'}
+>>> Ld.add_legend_entries('nodes', 'Receptor', style)
+>>> # Get the json representation of legend
+>>> Ld.get_legend_json()
+{'legend': {'nodes': {'Receptor': {'background-color': 'black',
+'shape': 'star'}}}}
+
+>>> # Adding another legend key with a given style and label
+>>> style = {'background-color': 'yellow', 'shape':'square'}
+>>> Ld.add_legend_entries('nodes', 'Intermediate Protein', style)
+>>> # Get the json representation of legend
+>>> Ld.get_legend_json()
+{'legend': {'nodes': {'Intermediate Protein': {'background-color': 'yellow',
+'shape': 'square'}}}}
+
+You can add JSON representation of legend at once by using the 
+:meth:`~graphspace_python.graphs.classes.gsgraph.GSLegend.set_legend_json` method.
+
+>>> Ld = GSLegend()
+>>> legend_json = {
+    "legend":{
+        "nodes":{
+            "Source Receptor": {
+                "shape":"triangle",
+                "background-color":"#ff1400"
+            }
+        },
+        "edges":{
+            "Phosphorylation":{
+                "line-color":"#0fcf25",
+                "line-style":"solid",
+                "arrow-shape":"triangle"
+            }
+        }
+    }
+}
+>>> Ld.set_legend_json(legend_json)
+>>> # Get the json representation of legend
+>>> Ld.get_legend_json()
+{'legend': {'edges': {'Phosphorylation': {'arrow-shape': 'triangle', 'line-color': '#0fcf25', 'line-style': 'solid'}}, 'nodes': {'Source Receptor': {'background-color': '#ff1400', 'shape': 'triangle'}}}}
+
+
+Updating legend key
+-------------------
+
+Setting a new style to an already present legend key will update its style.
+
+>>> style = {'line-color': "#0fcf25", "line-style":"dashed", "arrow-shape":"triangle"}
+>>> Ld.add_legend_entries('edges', 'Phosphorylation', style)
+>>> # Get the json representation of legend
+>>> Ld.get_legend_json()
+{'legend': {'edges': {'Phosphorylation': {'arrow-shape': 'triangle', 'line-color': '#0fcf25', 'line-style': 'dashed'}}, 'nodes': {'Source Receptor': {'background-color': '#ff1400', 'shape': 'triangle'}}}}
+
+Removing legend key
+-------------------
+
+You can remove an individual legend key at a time by using the 
+:meth:`~graphspace_python.graphs.classes.gsgraph.GSLegend.remove_legend_entries` method.
+
+>>> Ld.remove_legend_entries('nodes', 'Source Receptor')
+>>> # Get the json representation of legend
+>>> Ld.get_legend_json()
+{'legend': {'edges': {'Phosphorylation': {'arrow-shape': 'triangle', 'line-color': '#0fcf25', 'line-style': 'solid'}}, 'nodes': {}}}
+
+You can remove entire legend at once time by using the 
+:meth:`~graphspace_python.graphs.classes.gsgraph.GSLegend.delete_legend_json` method.
+
+>>> Ld.delete_legend_json()
+>>> # Get the json representation of legend
+>>> Ld.get_legend_json()
+{'legend': {}}
+
+
+Creating a graph with legend
+----------------------------
+
+>>> from graphspace_python.graphs.classes.gsgraph import GSGraph
+>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+>>> # Create an empty graph with no nodes and no edges.
+>>> G = GSGraph()
+>>> # Adding a node 'a' with a given popup and label
+>>> G.add_node('a', popup='sample node popup text', label='A')
+>>> G.nodes(data=True)
+[('a', {'id': 'a', 'popup': 'sample node popup text', 'name': 'a',
+'label': 'A'})]
+>>> # Adding style information for node 'a'
+>>> G.add_node_style('a', shape='ellipse', color='red', width=90, height=90)
+>>> # Adding a node 'b' with a given popup and label
+>>> G.add_node('b', popup='sample node popup text', label='B')
+>>> G.nodes(data=True)
+[('a', {'id': 'a', 'popup': 'sample node popup text', 'name': 'a',
+'label': 'A'}), ('b', {'id': 'b', 'popup': 'sample node popup text',
+'name': 'b', 'label': 'B'})]
+>>> # Adding style information for node 'b'
+>>> G.add_node_style('b', shape='triangle', color='blue', width=40, height=40)
+# Adding an edge between node 'a' and node 'b'
+>>> G.add_edge('a', 'b', directed=True, popup='sample edge popup')
+>>> # Adding style information for edge
+>>> G.add_edge_style('a', 'b', directed=True, edge_style='solid')
+>>> # Creating an empty legend
+>>> Ld = GSLegend()
+>>> legend_json = {
+    "legend":{
+        "nodes":{
+            "Source Receptor": {
+                "shape":"ellipse",
+                "background-color":"red"
+            },
+            "TF": {
+                "shape":"triangle",
+                "background-color":"blue"
+            }
+        },
+        "edges":{
+            "Phosphorylation":{
+                "line-color":"black",
+                "line-style":"solid",
+                "arrow-shape":"triangle"
+            }
+        }
+    }
+}
+>>> # Adding JSON representation of legend 
+>>> Ld.set_legend_json(legend_json)
+>>> # Adding the legend 'Ld' to the graph 'G'.
+>>> G.set_legend(Ld)
+>>> # Retrieving the legend 'Ld' from the graph 'G'.
+>>> Ld = G.get_legend()
+>>> Ld.get_legend_json()
+{'legend': {'edges': {'Phosphorylation': {'arrow-shape': 'triangle', 'line-color': 'black', 'line-style': 'solid'}}, 'nodes': {'Source Receptor': {'background-color': 'red', 'shape': 'ellipse'}, 'TF': {'background-color': 'blue', 'shape': 'triangle'}}}}
+
+
+Creating a layout with legend
+----------------------------
+
+>>> from graphspace_python.graphs.classes.gslayout import GSLayout
+>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+>>> # Create an empty layout with no node positions and style properties.
+>>> L = GSLayout()
+>>> # Setting position of a node 'a' with y and x coordinates
+>>> L.set_node_position('a', y=38.5, x=67.3)
+>>> # Setting position of a node 'b' with y and x coordinates
+>>> L.set_node_position('b', y=124, x=332.2)
+>>> # Add style for node 'a'
+>>> L.add_node_style('a', shape='ellipse', color='red', width=60, height=60)
+>>> # Add style for node 'b'
+>>> L.add_node_style('b', shape='triangle', color='blue', width=60, height=60)
+>>> # Add style for edge
+>>> L.add_edge_style('a', 'b', directed=True, edge_style='solid')
+>>> L.set_name('My Sample Layout')
+>>> # Creating an empty legend
+>>> Ld = GSLegend()
+>>> legend_json = {
+    "legend":{
+        "nodes":{
+            "Source Receptor": {
+                "shape":"ellipse",
+                "background-color":"red"
+            },
+            "TF": {
+                "shape":"triangle",
+                "background-color":"blue"
+            }
+        },
+        "edges":{
+            "Phosphorylation":{
+                "line-color":"black",
+                "line-style":"solid",
+                "arrow-shape":"triangle"
+            }
+        }
+    }
+}
+>>> # Adding JSON representation of legend 
+>>> Ld.set_legend_json(legend_json)
+>>> # Adding the legend 'Ld' to the layout 'L'.
+>>> L.set_legend(Ld)
+>>> # Retrieving the legend 'Ld' from the layout 'L'.
+>>> Ld = L.get_legend()
+>>> Ld.get_legend_json()
+{'legend': {'edges': {'Phosphorylation': {'arrow-shape': 'triangle', 'line-color': 'black', 'line-style': 'solid'}}, 'nodes': {'Source Receptor': {'background-color': 'red', 'shape': 'ellipse'}, 'TF': {'background-color': 'blue', 'shape': 'triangle'}}}}
+
+
 Responses
 ---------
 

--- a/graphspace_python/api/endpoint/groups.py
+++ b/graphspace_python/api/endpoint/groups.py
@@ -540,7 +540,7 @@ class Groups(object):
             'Both group_id and group_name can\'t be none when group object has no \'name\' or \'id\' attribute!')
 
     def get_group_graphs(self, group_name=None, group_id=None, group=None, limit=20, offset=0):
-    """Get graphs shared with a group provided the group_name, group_id or the group object itself.
+        """Get graphs shared with a group provided the group_name, group_id or the group object itself.
 
         Args:
                 group_name (str, optional): Name of the group. Defaults to None.
@@ -585,11 +585,11 @@ class Groups(object):
         Note:
                 Refer to the `tutorial <../tutorial/tutorial.html#fetching-graphs-shared-with-a-group>`_ for more about fetching graphs of a group.
         """
-
         query = {
             'limit': limit,
             'offset': offset
         }
+        
         if group is not None:
             if hasattr(group, 'id'):
                 group_id = group.id

--- a/graphspace_python/graphs/classes/gsgraph.py
+++ b/graphspace_python/graphs/classes/gsgraph.py
@@ -3,6 +3,7 @@ import networkx as nx
 import re
 from six import string_types
 from networkx.exception import NetworkXError
+from graphspace_python.graphs.classes.gslegend import GSLegend
 
 
 class GSGraph(nx.DiGraph):
@@ -705,6 +706,141 @@ class GSGraph(nx.DiGraph):
 		else:
 			del self.positions_json[node_name]
 
+	def set_legend(self, gslegend_obj):
+		"""Set the json representation of legend for the graph.
+
+		Args:
+			gslegend_obj (object): GSLegend object having JSON representation of legend for the graph.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gsgraph import GSGraph
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> L = GSLegend()
+			>>> legend_json = {
+			...	    "legend":{
+			...	        "nodes":{
+			...	            "Source Receptor": {
+			...	                "shape":"triangle",
+			...	                "background-color":"#ff1400"
+			...	             },
+			...	            "Receptor": {
+			...	                "shape":"circle",
+			...	                "background-color":"#1900ff"
+			...	            }
+			...	        },
+			...	        "edges":{
+			...	            "Phosphorylation":{
+			...	                "line-color":"#0fcf25",
+			...	                "line-style":"solid",
+			...	                "arrow-shape":"triangle"
+			...	            }
+			...	        }
+			...	    }
+			...	}
+			>>> L.set_legend_json(legend_json)
+
+			>>> G = GSGraph()
+			>>> G.set_name('My Sample Graph')
+			>>> G.set_tags(['sample'])
+			>>> G.set_legend(L)
+		"""
+		if(isinstance(gslegend_obj, GSLegend)):
+			legend_json = gslegend_obj.get_legend_json()
+			self.style_json.update(legend_json)
+		else:
+			raise Exception("set_legend method must take GSLegend object as argument")
+
+	def get_legend(self):
+		"""Get a GSLegend Object having JSON representation of legend for the graph.
+
+		Returns:
+			object: GSLegend Object having JSON representation of legend for the graph.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gsgraph import GSGraph
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> L = GSLegend()
+			>>> legend_json = {
+			...	    "legend":{
+			...	        "nodes":{
+			...	            "Source Receptor": {
+			...	                "shape":"triangle",
+			...	                "background-color":"#ff1400"
+			...	             },
+			...	            "Receptor": {
+			...	                "shape":"circle",
+			...	                "background-color":"#1900ff"
+			...	            }
+			...	        },
+			...	        "edges":{
+			...	            "Phosphorylation":{
+			...	                "line-color":"#0fcf25",
+			...	                "line-style":"solid",
+			...	                "arrow-shape":"triangle"
+			...	            }
+			...	        }
+			...	    }
+			...	}
+			>>> L.set_legend_json(legend_json)
+
+			>>> G = GSGraph()
+			>>> G.set_name('My Sample Graph')
+			>>> G.set_tags(['sample'])
+			>>> G.set_legend(L)
+			>>> G.get_legend()
+			<graphspace_python.graphs.classes.gslegend.GSLegend at 0x7f6ae5997e10>
+		"""
+		L = GSLegend()
+		legend_json = {'legend': self.style_json.get('legend',{})}
+		L.set_legend_json(legend_json)
+		return L
+
+	def delete_legend(self, gslegend_obj):
+		"""Set the json representation of legend for the graph to null.
+
+		Args:
+			gslegend_obj (object): GSLegend object having JSON representation of legend for the graph.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gsgraph import GSGraph
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> L = GSLegend()
+			>>> legend_json = {
+			...	    "legend":{
+			...	        "nodes":{
+			...	            "Source Receptor": {
+			...	                "shape":"triangle",
+			...	                "background-color":"#ff1400"
+			...	             },
+			...	            "Receptor": {
+			...	                "shape":"circle",
+			...	                "background-color":"#1900ff"
+			...	            }
+			...	        },
+			...	        "edges":{
+			...	            "Phosphorylation":{
+			...	                "line-color":"#0fcf25",
+			...	                "line-style":"solid",
+			...	                "arrow-shape":"triangle"
+			...	            }
+			...	        }
+			...	    }
+			...	}
+			>>> L.set_legend_json(legend_json)
+
+			>>> G = GSGraph()
+			>>> G.set_name('My Sample Graph')
+			>>> G.set_tags(['sample'])
+			>>> G.set_legend(L)
+			>>> L = G.get_legend()
+			>>> G.delete_legend(L)
+		"""
+		if(isinstance(gslegend_obj, GSLegend)):
+			gslegend_obj.delete_legend_json()
+			self.set_legend(gslegend_obj)
+		else:
+			raise Exception("delete_legend method must take GSLegend object as argument")
+
 	####################################################################
 	### NODE PROPERTY FUNCTIONS #################################################
 
@@ -1067,7 +1203,7 @@ class GSGraph(nx.DiGraph):
 		"""
 		if property_name in element and element[property_name] not in valid_property_values:
 			return element_selector + " contains illegal value for property: " + property_name + ".  Value given for this property was: " + \
-				   element[property_name] + ".  Accepted values for property: " + property_name + " are: [" + valid_property_values + "]"
+				   element[property_name] + ".  Accepted values for property: " + property_name + " are: [" + str(valid_property_values) + "]"
 
 		return None
 
@@ -1135,6 +1271,8 @@ class GSGraph(nx.DiGraph):
 			("mid-source-arrow-fill", GSGraph.ALLOWED_ARROW_FILL),
 			("target-arrow-fill", GSGraph.ALLOWED_ARROW_FILL),
 			("mid-target-arrow-fill", GSGraph.ALLOWED_ARROW_FILL)
+			# Edge legend specific
+			("arrow-shape", GSGraph.ALLOWED_ARROW_SHAPES)
 		]
 
 		for property_name, allowed_property_values in node_validity_checklist:

--- a/graphspace_python/graphs/classes/gsgraph.py
+++ b/graphspace_python/graphs/classes/gsgraph.py
@@ -744,11 +744,7 @@ class GSGraph(nx.DiGraph):
 			>>> G.set_tags(['sample'])
 			>>> G.set_legend(L)
 		"""
-		if(isinstance(gslegend_obj, GSLegend)):
-			legend_json = gslegend_obj.get_legend_json()
-			self.style_json.update(legend_json)
-		else:
-			raise Exception("set_legend method must take GSLegend object as argument")
+		self.__set_legend(self.style_json, gslegend_obj)
 
 	def get_legend(self):
 		"""Get a GSLegend Object having JSON representation of legend for the graph.
@@ -790,10 +786,7 @@ class GSGraph(nx.DiGraph):
 			>>> G.get_legend()
 			<graphspace_python.graphs.classes.gslegend.GSLegend at 0x7f6ae5997e10>
 		"""
-		L = GSLegend()
-		legend_json = {'legend': self.style_json.get('legend',{})}
-		L.set_legend_json(legend_json)
-		return L
+		return self.__get_legend(self.style_json)
 
 	def delete_legend(self, gslegend_obj):
 		"""Set the json representation of legend for the graph to null.
@@ -835,9 +828,46 @@ class GSGraph(nx.DiGraph):
 			>>> L = G.get_legend()
 			>>> G.delete_legend(L)
 		"""
+		self.__delete_legend(self.style_json, gslegend_obj)
+
+	def __set_legend(self, style_json, gslegend_obj):
+		"""Set the 'legend_json' attribute of GSLegend object to 'style_json' dict.
+
+		Args:
+			style_json (dict): Json representation for style.
+			gslegend_obj (object): GSLegend object having JSON representation of legend.
+
+		"""
+		if(isinstance(gslegend_obj, GSLegend)):
+			legend_json = gslegend_obj.get_legend_json()
+			style_json.update(legend_json)
+		else:
+			raise Exception("set_legend method must take GSLegend object as argument")
+
+	def __get_legend(self, style_json):
+		"""Set the legend json representation from 'style_json' dict to 'legend_json' attribute of GSLegend object and return the GSLegend object.
+
+		Args:
+			style_json (dict): Json representation for style.
+
+		Returns:
+			object: GSLegend Object having JSON representation of legend.
+		"""
+		L = GSLegend()
+		legend_json = {'legend': style_json.get('legend',{})}
+		L.set_legend_json(legend_json)
+		return L
+
+	def __delete_legend(self, style_json, gslegend_obj):
+		"""Set the legend json representation of 'style_json' dict to null.
+
+		Args:
+			style_json (dict): Json representation for style.
+			gslegend_obj (object): GSLegend object having JSON representation of legend.
+		"""
 		if(isinstance(gslegend_obj, GSLegend)):
 			gslegend_obj.delete_legend_json()
-			self.set_legend(gslegend_obj)
+			self.__set_legend(style_json, gslegend_obj)
 		else:
 			raise Exception("delete_legend method must take GSLegend object as argument")
 

--- a/graphspace_python/graphs/classes/gslayout.py
+++ b/graphspace_python/graphs/classes/gslayout.py
@@ -477,11 +477,8 @@ class GSLayout(object):
 			    'shape': 'ellipse'}}},
 			'style': []}
 		"""
-		if(isinstance(gslegend_obj, GSLegend)):
-			legend_json = gslegend_obj.get_legend_json()
-			self.style_json.update(legend_json)
-		else:
-			raise Exception("set_legend method must take GSLegend object as argument")
+		G = GSGraph()
+		G._GSGraph__set_legend(self.style_json, gslegend_obj)
 
 	def get_legend(self):
 		"""Get a GSLegend Object having JSON representation of legend for a layout.
@@ -516,9 +513,8 @@ class GSLayout(object):
 			>>> L.get_legend()
 			<graphspace_python.graphs.classes.gslegend.GSLegend at 0x7fdebc59d1d0>
 		"""
-		L = GSLegend()
-		legend_json = {'legend': self.style_json.get('legend',{})}
-		L.set_legend_json(legend_json)
+		G = GSGraph()
+		L = G._GSGraph__get_legend(self.style_json)
 		return L
 
 	def delete_legend(self, gslegend_obj):
@@ -557,8 +553,5 @@ class GSLayout(object):
 			>>> L.get_style_json()
 			{'legend': {}, 'style': []}
 		"""
-		if(isinstance(gslegend_obj, GSLegend)):
-			gslegend_obj.delete_legend_json()
-			self.set_legend(gslegend_obj)
-		else:
-			raise Exception("delete_legend method must take GSLegend object as argument")
+		G = GSGraph()
+		G._GSGraph__delete_legend(self.style_json, gslegend_obj)

--- a/graphspace_python/graphs/classes/gslayout.py
+++ b/graphspace_python/graphs/classes/gslayout.py
@@ -1,5 +1,6 @@
 import datetime
 from graphspace_python.graphs.classes.gsgraph import GSGraph
+from graphspace_python.graphs.classes.gslegend import GSLegend
 
 
 class GSLayout(object):
@@ -437,3 +438,127 @@ class GSLayout(object):
 				'style': style_dict
 			}]
 		})
+
+	def set_legend(self, gslegend_obj):
+		"""Set the json representation of legend for a layout.
+
+		Args:
+			gslegend_obj (object): GSLegend object having JSON representation of legend.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gslayout import GSLayout
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> Ld = GSLegend()
+			>>> legend_json = {
+			...	    "legend":{
+			...	        "nodes":{
+			...	            "TF": {
+			...	                "shape":"ellipse",
+			...	                "background-color":"#ff1400"
+			...	            }
+			...	        },
+			...	        "edges":{
+			...	            "Enzymatic Reaction":{
+			...	                "line-color":"#0fcf25",
+			...	                "line-style":"solid",
+			...	                "arrow-shape":"triangle"
+			...	            }
+			...	        }
+			...	    }
+			...	}
+			>>> Ld.set_legend_json(legend_json)
+			>>> L = GSLayout()
+			>>> L.set_legend(Ld)
+			>>> L.get_style_json()
+			{'legend': {'edges': {'Enzymatic Reaction': {'arrow-shape': 'triangle',
+			    'line-color': '#0fcf25',
+			    'line-style': 'solid'}},
+			  'nodes': {'TF': {'background-color': '#ff1400',
+			    'shape': 'ellipse'}}},
+			'style': []}
+		"""
+		if(isinstance(gslegend_obj, GSLegend)):
+			legend_json = gslegend_obj.get_legend_json()
+			self.style_json.update(legend_json)
+		else:
+			raise Exception("set_legend method must take GSLegend object as argument")
+
+	def get_legend(self):
+		"""Get a GSLegend Object having JSON representation of legend for a layout.
+
+		Returns:
+			object: GSLegend Object having JSON representation of legend.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gslayout import GSLayout
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> Ld = GSLegend()
+			>>> legend_json = {
+			...	    "legend":{
+			...	        "nodes":{
+			...	            "Source Receptor": {
+			...	                "shape":"ellipse",
+			...	                "background-color":"#ff1400"
+			...	            }
+			...	        },
+			...	        "edges":{
+			...	            "Enzymatic Reaction":{
+			...	                "line-color":"#0fcf25",
+			...	                "line-style":"solid",
+			...	                "arrow-shape":"triangle"
+			...	            }
+			...	        }
+			...	    }
+			...	}
+			>>> Ld.set_legend_json(legend_json)
+			>>> L = GSLayout()
+			>>> L.set_legend(Ld)
+			>>> L.get_legend()
+			<graphspace_python.graphs.classes.gslegend.GSLegend at 0x7fdebc59d1d0>
+		"""
+		L = GSLegend()
+		legend_json = {'legend': self.style_json.get('legend',{})}
+		L.set_legend_json(legend_json)
+		return L
+
+	def delete_legend(self, gslegend_obj):
+		"""Set the json representation of legend for the layout to null.
+
+		Args:
+			gslegend_obj (object): GSLegend object having JSON representation of legend.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gslayout import GSLayout
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> Ld = GSLegend()
+			>>> legend_json = {
+			...	    "legend":{
+			...	        "nodes":{
+			...	            "TF": {
+			...	                "shape":"ellipse",
+			...	                "background-color":"#ff1400"
+			...	            }
+			...	        },
+			...	        "edges":{
+			...	            "Enzymatic Reaction":{
+			...	                "line-color":"#0fcf25",
+			...	                "line-style":"solid",
+			...	                "arrow-shape":"triangle"
+			...	            }
+			...	        }
+			...	    }
+			...	}
+			>>> Ld.set_legend_json(legend_json)
+			>>> L = GSLayout()
+			>>> L.set_legend(Ld)
+			>>> Ld = L.get_legend()
+			>>> L.delete_legend(Ld)
+
+			>>> L.get_style_json()
+			{'legend': {}, 'style': []}
+		"""
+		if(isinstance(gslegend_obj, GSLegend)):
+			gslegend_obj.delete_legend_json()
+			self.set_legend(gslegend_obj)
+		else:
+			raise Exception("delete_legend method must take GSLegend object as argument")

--- a/graphspace_python/graphs/classes/gslegend.py
+++ b/graphspace_python/graphs/classes/gslegend.py
@@ -71,7 +71,7 @@ class GSLegend(object):
 			>>> G.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
 			>>> G.get_legend_json()
 			{'legend': {'nodes': {'Receptor': {'background-color': 'black',
-    		'shape': 'star'}}}}
+			'shape': 'star'}}}}
 		"""
 		return self.legend_json
 
@@ -89,7 +89,7 @@ class GSLegend(object):
 			>>> G.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
 			>>> G.get_legend_json()
 			{'legend': {'nodes': {'Receptor': {'background-color': 'black',
-    		'shape': 'star'}}}}
+			'shape': 'star'}}}}
 		"""
 		from graphspace_python.graphs.classes.gsgraph import GSGraph
 
@@ -123,10 +123,10 @@ class GSLegend(object):
 			>>> G.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
 			>>> G.get_legend_json()
 			{'legend': {'nodes': {'Receptor': {'background-color': 'black',
-    		'shape': 'star'}}}}
-    		>>> G.remove_legend_entries('nodes', 'Receptor')
-    		>>> G.get_legend_json()
-    		{'legend': {}}
+			'shape': 'star'}}}}
+			>>> G.remove_legend_entries('nodes', 'Receptor')
+			>>> G.get_legend_json()
+			{'legend': {}}
 		"""
 		legend_json = self.get_legend_json()
 		if(label not in legend_json['legend'].get(element_type, {})):
@@ -144,10 +144,10 @@ class GSLegend(object):
 			>>> G.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
 			>>> G.get_legend_json()
 			{'legend': {'nodes': {'Receptor': {'background-color': 'black',
-    		'shape': 'star'}}}}
-    		>>> G.delete_legend_json()
-    		>>> G.get_legend_json()
-    		{'legend': {}}
+			'shape': 'star'}}}}
+			>>> G.delete_legend_json()
+			>>> G.get_legend_json()
+			{'legend': {}}
 		"""
 		legend_json = {'legend':{}}
 		self.set_legend_json(legend_json)

--- a/graphspace_python/graphs/classes/gslegend.py
+++ b/graphspace_python/graphs/classes/gslegend.py
@@ -1,0 +1,169 @@
+import datetime
+
+
+class GSLegend(object):
+	"""GSLegend class.
+
+	A GSLegend stores the details of legend.
+
+	It holds the information about the legend such as legend label and style of legend keys.
+
+	It provides methods to add, retrieve, modify and remove the detatils of the legend.
+
+	Attributes:
+		legend_json (dict): JSON representation of the legend data.
+	"""
+	def __init__(self, *args, **kwargs):
+		"""Construct a new 'GSLegend' object.
+
+		"""
+		self.legend_json = {'legend': {}}
+
+	def set_legend_json(self, legend_json):
+		"""Set the json representation of the legend.
+
+		Args:
+			legend_json(dict): JSON representation of the legend data.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> G = GSLegend()
+			>>> legend_json = {
+			...	    "legend":{
+			...	        "nodes":{
+			...	            "Source Receptor": {
+			...	                "shape":"triangle",
+			...	                "background-color":"#ff1400"
+			...	             },
+			...	            "Receptor": {
+			...	                "shape":"circle",
+			...	                "background-color":"#1900ff"
+			...	            }
+			...	        },
+			...	        "edges":{
+			...	            "Phosphorylation":{
+			...	                "line-color":"#0fcf25",
+			...	                "line-style":"solid",
+			...	                "arrow-shape":"triangle"
+			...	            }
+			...	        }
+			...	    }
+			...	}
+			>>> G.set_legend_json(legend_json)
+			>>> G.get_legend_json()
+			{'legend': {'edges': {'Phosphorylation': {'arrow-shape': 'triangle', 'line-color': '#0fcf25', 'line-style': 'solid'}},
+			'nodes': {'Receptor': {'background-color': '#1900ff', 'shape': 'circle'},
+			'Source Receptor': {'background-color': '#ff1400', 'shape': 'triangle'}}}}
+		"""
+		self.legend_json = legend_json
+
+	def get_legend_json(self):
+		"""Get the json representation of the legend.
+
+		Returns:
+			dict: JSON representation of legend data.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> G = GSLegend()
+			>>> G.get_legend_json()
+			{'legend': {}}
+			>>> G.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+			>>> G.get_legend_json()
+			{'legend': {'nodes': {'Receptor': {'background-color': 'black',
+    		'shape': 'star'}}}}
+		"""
+		return self.legend_json
+
+	def add_legend_entries(self, element_type, label, style):
+		"""Add an individual legend key to the legend data.
+
+		Args:
+			element_type(str): Either nodes or edges.
+			label(str): Label of legend key.Passing an already existing label as param will update that legend key.
+			style(dict): Style dict of the legend key. Will contain attributes like node shape or edge type, color.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> G = GSLegend()
+			>>> G.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+			>>> G.get_legend_json()
+			{'legend': {'nodes': {'Receptor': {'background-color': 'black',
+    		'shape': 'star'}}}}
+		"""
+		from graphspace_python.graphs.classes.gsgraph import GSGraph
+
+		GSGraph.validate_style_properties(style, element_type)
+		if(element_type == 'nodes'):
+			GSLegend.validate_node_legend_properties(style)
+		else:
+			GSLegend.validate_edge_legend_properties(style)
+
+		legend_dict = dict()
+		legend_dict[label] = style
+
+		legend_json = self.get_legend_json()
+		if(element_type in legend_json['legend']):
+			legend_json['legend'][element_type].update(legend_dict)
+		else:
+			legend_json['legend'].update({element_type: legend_dict})
+
+		self.set_legend_json(legend_json)
+
+	def remove_legend_entries(self, element_type, label):
+		"""Remove an individual legend key from the legend data.
+
+		Args:
+			element_type(str): Either nodes or edges.
+			label(str): Label of legend key to be deleted.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> G = GSLegend()
+			>>> G.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+			>>> G.get_legend_json()
+			{'legend': {'nodes': {'Receptor': {'background-color': 'black',
+    		'shape': 'star'}}}}
+    		>>> G.remove_legend_entries('nodes', 'Receptor')
+    		>>> G.get_legend_json()
+    		{'legend': {}}
+		"""
+		legend_json = self.get_legend_json()
+		if(label not in legend_json['legend'].get(element_type, {})):
+			raise KeyError("No legend exist with this label. Please verify the legend to remove exists.")
+		else:
+			del legend_json['legend'][element_type][label]
+			self.set_legend_json(legend_json)
+
+	def delete_legend_json(self):
+		"""Set legend_json to NULL.
+
+		Examples:
+			>>> from graphspace_python.graphs.classes.gslegend import GSLegend
+			>>> G = GSLegend()
+			>>> G.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+			>>> G.get_legend_json()
+			{'legend': {'nodes': {'Receptor': {'background-color': 'black',
+    		'shape': 'star'}}}}
+    		>>> G.delete_legend_json()
+    		>>> G.get_legend_json()
+    		{'legend': {}}
+		"""
+		legend_json = {'legend':{}}
+		self.set_legend_json(legend_json)
+
+	@staticmethod
+	def validate_node_legend_properties(data_properties):
+		if "background-color" not in data_properties:
+			raise KeyError("All node legend must have background-color property.  Please verify that the new node legend meet this requirement.")
+		if "shape" not in data_properties:
+			raise KeyError("All node legend must have shape property.  Please verify that the new node legend meet this requirement.")
+
+	@staticmethod
+	def validate_edge_legend_properties(data_properties):
+		if "line-color" not in data_properties:
+			raise KeyError("All edge legend must have line-color property.  Please verify that the new edge legend meet this requirement.")
+		if "line-style" not in data_properties:
+			raise KeyError("All edge legend must have line-style property.  Please verify that the new edge legend meet this requirement.")
+		if "arrow-shape" not in data_properties:
+			raise KeyError("All edge legend must have arrow-shape property.  Please verify that the new edge legend meet this requirement.")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 install_requires = [i.strip() for i in open("requirements.txt").readlines()]
 
 setup(name='graphspace_python',
-      version='0.9.1',
+      version='1.0.0',
       description='Python client for GraphSpace REST API',
       url='http://github.com/adbharadwaj/graphspace-python',
       author='Aditya Bharadwaj',

--- a/tests/graphs_test.py
+++ b/tests/graphs_test.py
@@ -4,6 +4,7 @@ from graphspace_python.api.client import GraphSpace
 from graphspace_python.api.obj.graph import Graph
 from layouts_test import test_layouts_endpoint
 from groups_test import test_groups_endpoint
+from legend_test import test_gslegend
 from graphspace_python.api import errors
 
 
@@ -23,6 +24,7 @@ def test_graphs_endpoint():
 	test_get_graph_by_id()
 	test_delete_graph(name='MyTestGraph')
 	test_user_not_authorised_error(graph.id)
+	test_gslegend()
 
 
 def test_graph_already_exists_error(name):

--- a/tests/legend_test.py
+++ b/tests/legend_test.py
@@ -1,0 +1,87 @@
+import pytest
+from graphspace_python.graphs.classes.gslegend import GSLegend
+
+
+def test_gslegend():
+	test_set_legend_json()
+	test_add_legend_entries()
+	test_add_invalid_legend_entries()
+	test_add_invalid_style_legend_entries()
+	test_get_legend_json()
+	test_remove_legend_entries()
+	test_remove_invalid_legend_entries()
+	test_delete_legend_json()
+
+
+def test_set_legend_json():
+	Ld = GSLegend()
+
+	legend_json = {
+	   "legend":{
+	        "nodes":{
+	            "Source Receptor": {
+	                "shape":"triangle",
+	                "background-color":"#ff1400"
+	            }
+	        },
+	        "edges":{
+	            "Phosphorylation":{
+	                "line-color":"#0fcf25",
+	                "line-style":"solid",
+	                "arrow-shape":"triangle"
+	            }
+	        }
+	    }
+	}
+
+	Ld.set_legend_json(legend_json)
+	assert legend_json == Ld.legend_json
+
+
+def test_add_legend_entries():
+	expected_legend_json = {'legend':{'nodes': {'Receptor': {'background-color': 'black', 'shape':'star'}}}}
+	Ld = GSLegend()
+	Ld.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+	assert Ld.legend_json == expected_legend_json
+
+
+def test_add_invalid_legend_entries():
+	Ld = GSLegend()
+	style = {'background-color': 'yellow'}
+	with pytest.raises(KeyError):
+		Ld.add_legend_entries('nodes', 'TF', style)
+
+
+def test_add_invalid_style_legend_entries():
+	Ld = GSLegend()
+	style = {'background-color': 'yellow', 'shape':'decagon'}
+	with pytest.raises(KeyError):
+		Ld.add_legend_entries('nodes', 'TF', style)
+
+
+def test_get_legend_json():
+	Ld = GSLegend()
+	Ld.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+	assert Ld.legend_json == Ld.get_legend_json()
+
+
+def test_remove_legend_entries():
+	Ld = GSLegend()
+	Ld.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+	Ld.remove_legend_entries('nodes', 'Receptor')
+	assert len(Ld.get_legend_json()['legend']['nodes']) == 0
+
+
+def test_remove_invalid_legend_entries():
+	Ld = GSLegend()
+	Ld.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+	with pytest.raises(KeyError):
+		Ld.remove_legend_entries('nodes', 'TF')
+
+
+def test_delete_legend_json():
+	Ld = GSLegend()
+	Ld.add_legend_entries(element_type='nodes', label='Receptor', style={'background-color': 'black', 'shape':'star'})
+	Ld.add_legend_entries(element_type='edges', label='Physical', style={'line-color': 'black', 'line-style': 'solid', 'arrow-shape':'none'})
+	Ld.delete_legend_json()
+	assert len(Ld.get_legend_json()['legend']) == 0


### PR DESCRIPTION
## Purpose
This patch extends the API interface to update the legend using the graphspace-python package. Allow the users to use the graphspace_python client library to add, modify and remove legend data for an individual GraphSpace Network.

### Feature Details
Extending the API interface for legend support is an important feature for graphspace-python package. 

It allows user to do the following operations on the Graph
- Add legend to a graph
- Get legend of a graph
- Update legend of a graph
- Delete legend of a graph

It also allows user to do the following operations on the Layout
- Add legend to a layout
- Get legend of a layout
- Update legend of a layout
- Delete legend of a layout

## Approach
A new class `GSLegend` is added which stores the details of legend. It holds the information about the legend such as legend label and style of legend keys. It also provides methods to add, retrieve, modify and remove the detatils of the legend.

New methods are added to the `GSGraph`  class to add, retrieve and delete the legend details available in a particular instance of  `GSLegend` class to a particular graph.

New methods are added to the `GSLayout` class to add, retrieve and delete the legend details available in a particular instance of  `GSLegend` class to a particular layout.

**New files added**
`gslegend.py`: Contains the entire `GSLegend` class.

**Open Questions and Pre-Merge TODOs**

- [x] PR documentation
- [x] User documentation
- [x] Python documentation in Code
- [ ] Write tests in Python
