### PR TITLE
fix SyntaxWarning: replace "is not" with "!="

### DIFF
--- a/graphspace_python/api/client.py
+++ b/graphspace_python/api/client.py
@@ -71,7 +71,7 @@ class GraphSpace(object):
 		 		instance of the bound method.
 		"""
 		for method in instance_methods:
-			if method[0][0] is not '_':
+			if method[0][0] != '_':
 				self.__setattr__(method[0], method[1])
 
 	def set_api_host(self, host):


### PR DESCRIPTION
```
graphspace_python/api/client.py:74: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if method[0][0] is not '_':
```