### PR TITLE
Fix networkx compatibility error & add a dockerized folder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:20.04
+
+# create conda environment in advance and activate on run
+
+# install tools
+RUN  apt-get update \
+  && apt-get install -y wget \
+  && rm -rf /var/lib/apt/lists/*
+
+# install miniconda and configure bashrc
+ENV PATH /opt/conda/bin:$PATH
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda clean --all && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    conda init bash
+
+WORKDIR /home/graphspace-python
+
+# create graphspace-python conda environment
+COPY docker/minimal_env.yml ./docker/
+# requests module no longer part of conda - see https://github.com/vitchyr/rlkit/issues/107
+# for info about the CONDA_RESTORE_FREE_CHANNEL option.
+RUN CONDA_RESTORE_FREE_CHANNEL=1 conda env create -f docker/minimal_env.yml && \
+    echo "conda activate graphspace-python" >> ~/.bashrc
+
+# install graphspace-python
+COPY graphspace_python/ ./graphspace_python
+
+# add an ENV entry so graphspace_python can be accessed anywhere:
+# https://stackoverflow.com/questions/49631146/how-do-you-add-a-path-to-pythonpath-in-a-dockerfile/49631407
+ENV PYTHONPATH "${PYTHONPATH}:/home/graphspace-python"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,49 @@
+# Dockerized Graphspace Python Client
+
+## Steps Illustrated Below
+- Build `graphspace-python` docker container
+- Run `graphspace-python` docker image interactively and mount example data to container
+- Run `graphspace-python` software on an example in this directory.
+
+## Requirements
+- Docker software
+- Mac, linux, or Windows machine
+
+## Build (Mac/Linux/Windows)
+
+To build image: start from `graphspace-python` repository __root__ directory and call:
+
+`docker build -t graphspace-python/graphspace-python -f docker/Dockerfile .`
+
+To run the image interactively (with no linked data):
+
+`docker run -it graphspace-python/graphspace-python bash`
+
+## Run (Mac/Linux)
+
+To mount the example data inside the container:
+
+`docker run -v /$(pwd)/docker/example:/home/graphspace-python/example -it graphspace-python/graphspace-python bash`
+
+then inside the container in the `/home/graphspace-python/example` directory call:
+
+`python test.py example-graph.txt compbio@reed.edu compbio`
+
+the output files will be linked to the host machine in the example subdirectory.
+
+
+## Run (Windows) -- AR did not test.
+
+To use the docker container with windows, use a bash terminal such as Git for Windows.
+
+To run container in Git for Windows:
+
+`winpty docker run -it graphspace-python/graphspace-python bash`
+
+To run in Git for Windows and mount the example data inside the container:
+
+`winpty docker run -v /$(pwd)/docker/example:/home/graphspace-python/example -it graphspace-python/graphspace-python bash`
+
+then inside the container in the `/home/graphspace-python/example` directory call:
+
+`python test.py example-graph.txt compbio@reed.edu compbio`

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,4 +45,4 @@ To run in Git for Windows and mount the example data inside the container:
 
 then inside the container in the `/home/graphspace-python/example` directory call:
 
-`python test.py example-graph.txt compbio@reed.edu compbio`
+`python test.py example-graph.txt user6@example.com user6`

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,6 @@ then inside the container in the `/home/graphspace-python/example` directory cal
 
 the output files will be linked to the host machine in the example subdirectory.
 
-
 ## Run (Windows) -- AR did not test.
 
 To use the docker container with windows, use a bash terminal such as Git for Windows.

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ To mount the example data inside the container:
 
 then inside the container in the `/home/graphspace-python/example` directory call:
 
-`python test.py example-graph.txt compbio@reed.edu compbio`
+`python test.py example-graph.txt user6@example.com user6`
 
 the output files will be linked to the host machine in the example subdirectory.
 

--- a/docker/example/example-graph.txt
+++ b/docker/example/example-graph.txt
@@ -1,0 +1,14 @@
+A B
+A C
+B H
+B F
+H I
+C D
+D F
+F G
+E F
+C E
+E K
+K G
+E L
+J K

--- a/docker/example/test.py
+++ b/docker/example/test.py
@@ -1,0 +1,37 @@
+from graphspace_python.api.client import GraphSpace
+from graphspace_python.graphs.classes.gsgraph import GSGraph
+import networkx as nx
+import time
+import sys
+
+def main(graph_file,username,password):
+
+	# read file as networkx graph
+	nxG = nx.read_edgelist(graph_file)
+
+	# convert networkx graph to GraphSpace object
+	G = GSGraph()
+	G.set_name('Docker Example %.4f' % (time.time()))
+	for n in nxG.nodes():
+		G.add_node(n,label=n,popup='Node %s' % (n))
+		G.add_node_style(n,color='#ACCE9A',shape='rectangle',width=30,height=30)
+	for u,v in nxG.edges():
+		G.add_edge(u,v,popup='Edge %s-%s' % (u,v))
+		G.add_edge_style(u,v,width=2,color='#281D6A')
+
+	# post with unique timestamp
+	gs = GraphSpace(username,password)
+	try:
+		graph = gs.update_graph(G)
+	except:
+		graph = gs.post_graph(G)
+	print('posted graph')
+	return
+
+if __name__ == '__main__':
+	if len(sys.argv) != 4:
+		print('USAGE: python test.py <GRAPH_FILE> <USERNAME> <PASSWORD>\n\n\twhere <USERNAME> and <PASSWORD> are GraphSpace username and password.')
+		print('CURRENT ARGS:',sys.argv)
+		sys.exit()
+
+	main(sys.argv[1],sys.argv[2],sys.argv[3])

--- a/docker/minimal_env.yml
+++ b/docker/minimal_env.yml
@@ -1,0 +1,9 @@
+name: graphspace-python
+channels:
+dependencies:
+  - future
+  - networkx=1.11
+  - requests=2.10.0
+  - pytest
+  - mock
+  - python=3.5

--- a/graphspace_python/graphs/classes/gsgraph.py
+++ b/graphspace_python/graphs/classes/gsgraph.py
@@ -471,7 +471,7 @@ class GSGraph(nx.DiGraph):
 		attr_dict.update({"source": source, "target": target})
 
 		GSGraph.validate_edge_data_properties(data_properties=attr_dict, nodes_list=self.nodes())
-		if float(nx.__version__) >= 2:
+		if nx.__version__[0] == '2': # networkx 2.x
 			super(GSGraph, self).add_edge(source, target, **attr_dict)
 		else:
 			super(GSGraph, self).add_edge(source, target, attr_dict)
@@ -524,7 +524,7 @@ class GSGraph(nx.DiGraph):
 		attr_dict.update({"name": node_name, "id": node_name})
 
 		GSGraph.validate_node_data_properties(data_properties=attr_dict, nodes_list=self.nodes())
-		if float(nx.__version__) >= 2:
+		if nx.__version__[0] == '2': # networkx 2.x
 			super(GSGraph, self).add_node(node_name, **attr_dict)
 		else:
 			super(GSGraph, self).add_node(node_name, attr_dict)


### PR DESCRIPTION
Hi All - this pull request addresses an error and also contributes a Dockerized example. 

1. NetworkX versions are often listed as `2.3.1`, but the check for networkx v1 vs. v2 in `gsgraph.py` tries to cast this as a float. According to networkx's [migration guide](https://networkx.org/documentation/stable/release/migration_guide_from_1.x_to_2.0.html), the proper way to check is to see if `nx.__version__[0]` is a `'1'` or `'2'`. 
2. The Dockerized folder is similar to that of [PathLinker's `docker/` directory](https://github.com/Murali-group/PathLinker/tree/master/docker). This may be useful for some.

I"d be fine if the error was fixed but this pull request is not merged - up to you. Thanks - Anna