### PR TITLE
Make requests version less strict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 future
 networkx>=1.11
-requests==2.20.0
+requests>=2.20.0
 sphinx-rtd-theme
 sphinx
 recommonmark


### PR DESCRIPTION
Follows up on #36.  The requirement `requests==2.20.0` was still too strict for other packages.  Relaxing it to `>=` worked.